### PR TITLE
Update Info.plist to add NSCameraUsageDescription key.

### DIFF
--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -40,5 +40,7 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Camera used to scan credit cards</string>
 </dict>
 </plist>


### PR DESCRIPTION
App crashes when Camera page is opened due to iOS 10's new requirements to have Usage Descriptions to use many platform features, using the Camera in app being one of them. See: https://blog.xamarin.com/new-ios-10-privacy-permission-settings/